### PR TITLE
Consider non FSA actions

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -1,12 +1,11 @@
 export const type = '@@redux-batch-middleware/BATCH';
 
-export const batch = ({ dispatch }) => {
-    return (next) => (action) => {
-        return Array.isArray(action)
-            ? dispatch({ type: type, payload: action })
-            : next(action);
-    };
-};
+export const batch = ({ dispatch }) => (next) => (action) =>
+  Array.isArray(action)
+    ? action.every(a => typeof a !== 'function')
+      ? dispatch({ type: type, payload: action })
+      : action.filter(Boolean).map(dispatch)
+    : next(action);
 
 export const batching = (reducer) => {
     return function batcher(state, action) {

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,8 +1,10 @@
+import { isFSA } from 'flux-standard-action';
+
 export const type = '@@redux-batch-middleware/BATCH';
 
 export const batch = ({ dispatch }) => (next) => (action) =>
   Array.isArray(action)
-    ? action.every(a => typeof a !== 'function')
+    ? action.every(isFSA)
       ? dispatch({ type: type, payload: action })
       : action.filter(Boolean).map(dispatch)
     : next(action);

--- a/modules/index.tape.js
+++ b/modules/index.tape.js
@@ -1,12 +1,14 @@
 import test from 'tape';
+import { isFSA } from 'flux-standard-action';
 import { applyMiddleware, combineReducers, createStore } from 'redux';
 
 import { batch, batching, type as batchType } from './index';
 
 
-const createBatchStore = () => {
+const createBatchStore = (middlewares=[]) => {
     const middleware = [
-        batch
+        batch,
+        ...middlewares
     ];
 
     const root = combineReducers({
@@ -54,4 +56,26 @@ test('can dispatch batch action', (t) => {
     t.same(actions.map((action) => action.type), [type1, type2]);
 
     t.end();
+});
+
+test('can handle non-fsa actions', (t) => {
+  const customMiddleware = ({ dispatch }) => next => action => {
+    if(typeof action === 'function') {
+      return action(dispatch);
+    }
+
+    next(action);
+  };
+
+  const type1 = 'action type 1';
+  const type2 = 'action type 2';
+
+  const store = createBatchStore([customMiddleware]);
+
+  const action = [{ type: type1 }, dispatch => dispatch({ type: type2 }) ];
+  const result = store.dispatch(action);
+  const actions = store.getState().actions;
+
+  t.same(actions.map((action) => action.type), [type1, type2]);
+  t.end();
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint": "^3.12.2",
     "eslint-config-coderesque": "^3.0.1",
     "faucet": "^0.0.1",
+    "flux-standard-action": "^1.2.0",
     "redux": "^3.3.1",
     "tape": "^4.6.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,6 +1175,12 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flux-standard-action@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/flux-standard-action/-/flux-standard-action-1.2.0.tgz#d2d41612dde4cebddd11a76cfead8e84fc69ebdc"
+  dependencies:
+    lodash "^4.0.0"
+
 for-each@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"


### PR DESCRIPTION
In case we have a non-flux standard action, we'd like to give the processing responsibility to other middlewares.
For example, if the array contains a thunk we'd like redux thunk to deal with it.